### PR TITLE
security: harden release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,27 +35,32 @@ on:
         type: boolean
 
 permissions:
-  id-token: write
-  contents: write
-  packages: write
+  contents: read
 
 jobs:
   delete:
+    permissions:
+      contents: write
+      packages: write
     uses: Checkmarx/ast-cli-javascript-wrapper-runtime-cli/.github/workflows/delete-packages-and-releases.yml@main
     with:
       tag: ${{ inputs.jsTag }}
     secrets: inherit
     if: inputs.dev == true
   release:
+    permissions:
+      id-token: write
+      contents: write
+      packages: write
     runs-on: cx-public-ubuntu-x64
     env:
-      GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BRANCH_NAME: npm-version-patch
     outputs:
       TAG_NAME: ${{ steps.generate_tag_name.outputs.TAG_NAME }}
       CLI_VERSION: ${{ steps.extract_cli_version.outputs.CLI_VERSION }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 
@@ -64,23 +69,26 @@ jobs:
           git config user.name github-actions
           git config user.email github-actions@github.com
 
-      - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22.11.0
           registry-url: https://npm.pkg.github.com/
 
       - name: Generate Tag name
         id: generate_tag_name
+        env:
+          INPUT_DEV: ${{ inputs.dev }}
+          INPUT_JS_TAG: ${{ inputs.jsTag }}
         run: |
-          if [ "${{ inputs.dev }}" == "true" ]; then
-            TAG_NAME=$(npm version prerelease --preid=${{ inputs.jsTag }} --no-git-tag-version --allow-same-version)
+          if [ "$INPUT_DEV" == "true" ]; then
+            TAG_NAME=$(npm version prerelease --preid="$INPUT_JS_TAG" --no-git-tag-version --allow-same-version)
           else
             TAG_NAME=$(npm version patch --no-git-tag-version)
           fi
-          
+
           echo "Generated TAG_NAME: $TAG_NAME"
           echo "TAG_NAME=$TAG_NAME" >> $GITHUB_ENV
-          echo "::set-output name=TAG_NAME::$TAG_NAME"
+          echo "TAG_NAME=$TAG_NAME" >> $GITHUB_OUTPUT
       
       - name: Extract CLI version
         id: extract_cli_version
@@ -88,12 +96,16 @@ jobs:
           CLI_VERSION=$(cat checkmarx-ast-cli.version | grep -Eo '^[0-9]+\.[0-9]+\.[0-9]+')
           echo "CLI version being packed is $CLI_VERSION"
           echo "CLI_VERSION=$CLI_VERSION" >> $GITHUB_ENV
-          echo "::set-output name=CLI_VERSION::$CLI_VERSION"
+          echo "CLI_VERSION=$CLI_VERSION" >> $GITHUB_OUTPUT
 
       - name: Check if CLI version is latest
         id: check_latest_cli_version
+        env:
+          INPUT_DEV: ${{ inputs.dev }}
+          INPUT_CLI_TAG: ${{ inputs.cliTag }}
+          GIT_REF: ${{ github.ref }}
         run: |
-          if [ "${{ inputs.dev }}" == "false" ] || [ -n "${{ inputs.cliTag }}" ] || [ "${{ github.ref }}" != "refs/heads/main" ]; then
+          if [ "$INPUT_DEV" == "false" ] || [ -n "$INPUT_CLI_TAG" ] || [ "$GIT_REF" != "refs/heads/main" ]; then
             exit 0
           fi
           
@@ -125,13 +137,13 @@ jobs:
       - name: Wait for PR to be created
         id: pr
         if: inputs.dev == false
-        uses: octokit/request-action@872c5c97b3c85c23516a572f02b31401ef82415d #v2.3.1
+        uses: octokit/request-action@b91aabaa861c777dcdb14e2387e30eddf04619ae # v3.0.0
         with:
           route: GET /repos/${{ github.repository }}/pulls?head=${{ github.repository_owner }}:${{ env.BRANCH_NAME }}
 
       - name: Merge Pull Request
         if: inputs.dev == false
-        uses: octokit/request-action@872c5c97b3c85c23516a572f02b31401ef82415d #v2.3.1
+        uses: octokit/request-action@b91aabaa861c777dcdb14e2387e30eddf04619ae # v3.0.0
         with:
           route: PUT /repos/${{ github.repository }}/pulls/${{ steps.create_pr.outputs.pull-request-number }}/merge
           merge_method: squash
@@ -144,14 +156,16 @@ jobs:
           git push --tags
 
       - name: Publish npm package
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_DEV: ${{ inputs.dev }}
+          INPUT_JS_TAG: ${{ inputs.jsTag }}
         run: |
-          if [ ${{ inputs.dev }} == true ]; then
-            npm publish --tag=${{ inputs.jsTag }}
+          if [ "$INPUT_DEV" == "true" ]; then
+            npm publish --tag="$INPUT_JS_TAG"
           else
             npm publish --access public
           fi
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.PERSONAL_ACCESS_TOKEN}}
 
       - name: Create Release
         uses: step-security/action-gh-release@277bfa82abcfdb73e5bbb19e213fd76532ee2be5 # v3.0.0
@@ -161,26 +175,26 @@ jobs:
           generate_release_notes: true
           prerelease: ${{ inputs.dev }}
   
-  notify:
-    if: inputs.dev == false
-    needs: release
-    uses: Checkmarx/plugins-release-workflow/.github/workflows/release-notify.yml@main
-    with:
-      product_name: Javascript Runtime Wrapper
-      release_version: ${{ needs.release.outputs.TAG_NAME }}
-      cli_release_version: ${{ needs.release.outputs.CLI_VERSION }}
-      release_author: "Sypher Team"
-      release_url: https://github.com/Checkmarx/ast-cli-javascript-wrapper-runtime-cli/releases/tag/${{ needs.release.outputs.TAG_NAME }}
-      jira_product_name: JS_RUNTIME_WRAPPER
-    secrets: inherit
+  # notify:
+  #   if: inputs.dev == false
+  #   needs: release
+  #   uses: Checkmarx/plugins-release-workflow/.github/workflows/release-notify.yml@main
+  #   with:
+  #     product_name: Javascript Runtime Wrapper
+  #     release_version: ${{ needs.release.outputs.TAG_NAME }}
+  #     cli_release_version: ${{ needs.release.outputs.CLI_VERSION }}
+  #     release_author: "Sypher Team"
+  #     release_url: https://github.com/Checkmarx/ast-cli-javascript-wrapper-runtime-cli/releases/tag/${{ needs.release.outputs.TAG_NAME }}
+  #     jira_product_name: JS_RUNTIME_WRAPPER
+  #   secrets: inherit
 
-  dispatch_auto_release:
-    name: Update ADO Extension With new Wrapper Version
-    if: inputs.dev == false
-    needs: notify
-    uses: Checkmarx/plugins-release-workflow/.github/workflows/dispatch-workflow.yml@main
-    with:
-      cli_version: ${{ needs.release.outputs.CLI_VERSION }}
-      is_cli_release: false
-      is_js_runtime_release: true
-    secrets: inherit
+  # dispatch_auto_release:
+  #   name: Update ADO Extension With new Wrapper Version
+  #   if: inputs.dev == false
+  #   needs: notify
+  #   uses: Checkmarx/plugins-release-workflow/.github/workflows/dispatch-workflow.yml@main
+  #   with:
+  #     cli_version: ${{ needs.release.outputs.CLI_VERSION }}
+  #     is_cli_release: false
+  #     is_js_runtime_release: true
+  #   secrets: inherit


### PR DESCRIPTION
## Summary

- Move permissions from workflow level to job level (least privilege)
- Replace deprecated `::set-output` with `$GITHUB_OUTPUT`
- Fix script injection by moving `inputs.*` context expressions to `env` vars in `run` steps
- Replace `PERSONAL_ACCESS_TOKEN` with `GITHUB_TOKEN`
- Update pinned action SHAs: `actions/checkout` v6.0.3, `actions/setup-node` v6.4.0, `octokit/request-action` v3.0.0
- Comment out `notify` and `dispatch_auto_release` jobs