### PR TITLE
security: replace dev-drprasad/delete-older-releases with gh CLI

### DIFF
--- a/.github/workflows/delete-packages-and-releases.yml
+++ b/.github/workflows/delete-packages-and-releases.yml
@@ -14,37 +14,42 @@ on:
         required: true
 
 permissions:
-  id-token: write
-  contents: write
-  packages: write
-
+  contents: read
 
 jobs:
   delete:
+    permissions:
+      contents: write
+      packages: write
     runs-on: cx-public-ubuntu-x64
     steps:
 
       - name: Delete npm packages
         continue-on-error: true
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          echo "Deleting all npm packages whose name ends with '-${INPUT_TAG}.0'"
 
-          echo "Deleting all npm packages whose name ends with '-${{inputs.tag}}.0'"
-
-          VERSION_IDS=($(curl -L -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.PERSONAL_ACCESS_TOKEN }}" -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/orgs/Checkmarx/packages/npm/ast-cli-javascript-wrapper-runtime-cli/versions | jq '.[]|select(.name | contains("-${{inputs.tag}}.0"))|.id'))
+          VERSION_IDS=($(curl -L -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $GH_TOKEN" -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/orgs/Checkmarx/packages/npm/ast-cli-javascript-wrapper-runtime-cli/versions | jq ".[]|select(.name | contains(\"-${INPUT_TAG}.0\"))|.id"))
 
           for versionId in "${VERSION_IDS[@]}"
           do
              echo "Deleting version $versionId..."
-             curl -L -X DELETE -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.PERSONAL_ACCESS_TOKEN }}" -H "X-GitHub-Api-Version: 2022-11-28" "https://api.github.com/orgs/Checkmarx/packages/npm/ast-cli-javascript-wrapper-runtime-cli/versions/$versionId"
+             curl -L -X DELETE -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $GH_TOKEN" -H "X-GitHub-Api-Version: 2022-11-28" "https://api.github.com/orgs/Checkmarx/packages/npm/ast-cli-javascript-wrapper-runtime-cli/versions/$versionId"
              echo "Version $versionId deleted successfully!"
           done
 
       - name: Delete releases and tags
         continue-on-error: true
-        uses: dev-drprasad/delete-older-releases@dfbe6be2a006e9475dfcbe5b8d201f1824c2a9fe #v0.3.4
         env:
-          GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-        with:
-          keep_latest: 0
-          delete_tag_pattern: "-${{inputs.tag}}.0"
-          delete_tags: true
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          gh release list --limit 100 --json tagName \
+            --jq ".[] | select(.tagName | contains(\"-${INPUT_TAG}.0\")) | .tagName" \
+            | while IFS= read -r tag; do
+                echo "Deleting release and tag: $tag"
+                gh release delete "$tag" --yes --cleanup-tag || true
+              done


### PR DESCRIPTION
## Summary

- Replace `dev-drprasad/delete-older-releases` with equivalent `gh release delete --cleanup-tag` commands
- `gh` CLI is pre-installed on all GitHub-hosted runners — no external action needed